### PR TITLE
Basic FreeBSD Support for non-GUI parts

### DIFF
--- a/code/NALib/src/NABase/NAEnvironment.h
+++ b/code/NALib/src/NABase/NAEnvironment.h
@@ -40,6 +40,7 @@
 #define NA_OS_UNKNOWN   0
 #define NA_OS_MAC_OS_X  1
 #define NA_OS_WINDOWS   2
+#define NA_OS_FREEBSD   3
 
 // Figuring out what system this is. The following macros will be defined:
 //
@@ -61,6 +62,7 @@
 // In the future, there might be more or different macros
 #if defined _WIN32
   #define NA_OS NA_OS_WINDOWS
+  #define NA_IS_POSIX 0
   #undef  NA_ENDIANNESS_HOST
   #define NA_ENDIANNESS_HOST NA_ENDIANNESS_LITTLE
   #if defined _M_ARM
@@ -79,6 +81,7 @@
 
 #elif defined __APPLE__ && __MACH__
   #define NA_OS NA_OS_MAC_OS_X
+  #define NA_IS_POSIX 1
   #if defined __LITTLE_ENDIAN__
     #undef  NA_ENDIANNESS_HOST
     #define NA_ENDIANNESS_HOST NA_ENDIANNESS_LITTLE
@@ -118,6 +121,25 @@
     #define NA_COCOA_RELEASE(obj) [(id)(obj) release]
     #define NA_COCOA_AUTORELEASE(obj) [(id)(obj) autorelease]
     #define NA_COCOA_SUPER_DEALLOC() [super dealloc]
+  #endif
+
+#elif defined __FreeBSD__
+  #define NA_OS NA_OS_FREEBSD
+  #define NA_IS_POSIX 1
+
+  #if defined __LITTLE_ENDIAN__
+    #undef  NA_ENDIANNESS_HOST
+    #define NA_ENDIANNESS_HOST NA_ENDIANNESS_LITTLE
+  #elif defined __BIG_ENDIAN__
+    #undef  NA_ENDIANNESS_HOST
+    #define NA_ENDIANNESS_HOST NA_ENDIANNESS_BIG
+  #endif
+  #if defined __LP64__
+    #define NA_ADDRESS_BITS NA_TYPE64_BITS
+    #define NA_SIZE_T_BITS  NA_TYPE64_BITS
+  #else
+    #define NA_ADDRESS_BITS NA_TYPE32_BITS
+    #define NA_SIZE_T_BITS  NA_TYPE32_BITS
   #endif
 
 #else

--- a/code/NALib/src/NAMath/Core/NAMathOperatorsII.h
+++ b/code/NALib/src/NAMath/Core/NAMathOperatorsII.h
@@ -228,7 +228,7 @@ NA_IDEF double naCbrt(double x){
   #endif
   #if NA_OS == NA_OS_WINDOWS
     return pow(x, NA_THIRD);
-  #elif NA_OS == NA_OS_MAC_OS_X
+  #elif NA_IS_POSIX
     return cbrt(x);
   #endif
 }
@@ -239,7 +239,7 @@ NA_IDEF float naCbrtf(float x){
   #endif
   #if NA_OS == NA_OS_WINDOWS
     return powf(x, NA_THIRDf);
-  #elif NA_OS == NA_OS_MAC_OS_X
+  #elif NA_IS_POSIX
     return cbrtf(x);
   #endif
 }
@@ -285,14 +285,14 @@ NA_IDEF float naCeilf(float x){
 NA_IDEF double naRound(double x){
   #if NA_OS == NA_OS_WINDOWS
     return floor(x + .5);
-  #elif NA_OS == NA_OS_MAC_OS_X
+  #elif NA_IS_POSIX
     return round(x);
   #endif
 }
 NA_IDEF float naRoundf(float x){
   #if NA_OS == NA_OS_WINDOWS
     return floorf(x + .5f);
-  #elif NA_OS == NA_OS_MAC_OS_X
+  #elif NA_IS_POSIX
     return roundf(x);
   #endif
 }
@@ -451,7 +451,7 @@ NA_IDEF double naLog2(double x){
   #endif
   #if NA_OS == NA_OS_WINDOWS
     return log(x) * NA_INV_LOGOF2;
-  #elif NA_OS == NA_OS_MAC_OS_X
+  #elif NA_IS_POSIX
     return log2(x);
   #endif
 }
@@ -462,7 +462,7 @@ NA_IDEF float naLog2f(float x){
   #endif
   #if NA_OS == NA_OS_WINDOWS
     return logf(x) * NA_INV_LOGOF2f;
-  #elif NA_OS == NA_OS_MAC_OS_X
+  #elif NA_IS_POSIX
     return log2f(x);
   #endif
 }
@@ -503,14 +503,14 @@ NA_IDEF NAi64 naLog2i64(NAi64 x){
 NA_IDEF double naExp2(double x){
   #if NA_OS == NA_OS_WINDOWS
     return pow(2., x);
-  #elif NA_OS == NA_OS_MAC_OS_X
+  #elif NA_IS_POSIX
     return exp2(x);
   #endif
 }
 NA_IDEF float naExp2f(float x){
   #if NA_OS == NA_OS_WINDOWS
     return powf(2.f, x);
-  #elif NA_OS == NA_OS_MAC_OS_X
+  #elif NA_IS_POSIX
     return exp2f(x);
   #endif
 }

--- a/code/NALib/src/NAMath/Core/NARandomII.h
+++ b/code/NALib/src/NAMath/Core/NARandomII.h
@@ -12,7 +12,7 @@
 NA_IDEF NAInt naRand(){
   #if NA_OS == NA_OS_WINDOWS
     return rand();
-  #elif NA_OS == NA_OS_MAC_OS_X
+  #elif NA_IS_POSIX
     return rand();
   #endif
 }
@@ -21,7 +21,7 @@ NA_IDEF NAInt naRand(){
 NA_IDEF void naSRand(uint32 seed){
   #if NA_OS == NA_OS_WINDOWS
     srand(seed);
-  #elif NA_OS == NA_OS_MAC_OS_X
+  #elif NA_IS_POSIX
     srand(seed);
   #endif
 }

--- a/code/NALib/src/NAUtility/Core/NAFile.c
+++ b/code/NALib/src/NAUtility/Core/NAFile.c
@@ -25,7 +25,7 @@ NA_DEF NABool naIsDir(const char* path){
     retValue = (GetFileAttributes(sysstring)  & FILE_ATTRIBUTE_DIRECTORY) ? NA_TRUE : NA_FALSE;
     free(sysstring);
     return retValue;
-  #elif NA_OS == NA_OS_MAC_OS_X
+  #elif NA_IS_POSIX
     struct stat stat_struct;
     stat(path, &stat_struct);
     return (stat_struct.st_mode & S_IFDIR) ? NA_TRUE : NA_FALSE;
@@ -41,7 +41,7 @@ NA_DEF NABool naIsHidden(const char* path){
     retValue = (GetFileAttributes(sysstring) & FILE_ATTRIBUTE_HIDDEN) ? NA_TRUE : NA_FALSE;
     free(sysstring);
     return retValue;
-  #elif NA_OS == NA_OS_MAC_OS_X
+  #elif NA_IS_POSIX
     return (path[0] == '.');
   #endif
 }

--- a/code/NALib/src/NAUtility/Core/NAMemory/NAMemoryII.h
+++ b/code/NALib/src/NAUtility/Core/NAMemory/NAMemoryII.h
@@ -12,7 +12,9 @@
 #include "NAPointerII.h"
 #include "NARuntimeII.h"
 
-
+#if NA_IS_POSIX
+#include <unistd.h>
+#endif
 
 // //////////////////////////////////////
 // Accessing informations about the memory system

--- a/code/NALib/src/NAUtility/Core/NAStringII.h
+++ b/code/NALib/src/NAUtility/Core/NAStringII.h
@@ -20,7 +20,7 @@ NA_IDEF size_t naStrlen(const NAUTF8Char* str){
 NA_IDEF size_t naVsnprintf(NAUTF8Char* buffer, size_t length, const NAUTF8Char* newstr, va_list argumentList){
   #if NA_OS == NA_OS_WINDOWS
     return (size_t)_vsnprintf_s(buffer, (size_t)length, (size_t)length, newstr, argumentList);
-  #elif NA_OS == NA_OS_MAC_OS_X
+  #elif NA_IS_POSIX
     return (size_t)vsnprintf((char*)buffer, (size_t)length, (const char*)newstr, argumentList);
   #endif
 }
@@ -32,7 +32,7 @@ NA_IDEF size_t naVsnprintf(NAUTF8Char* buffer, size_t length, const NAUTF8Char* 
 NA_IDEF size_t naVarargStringLength(const NAUTF8Char* string, va_list args){
 #if NA_OS == NA_OS_WINDOWS
   return (size_t)_vscprintf(string, args);
-#elif NA_OS == NA_OS_MAC_OS_X
+#elif NA_IS_POSIX
   return naVsnprintf(NA_NULL, 0, string, args);
 #endif
 }

--- a/code/NALib/src/NAUtility/NADateTime.h
+++ b/code/NALib/src/NAUtility/NADateTime.h
@@ -13,7 +13,7 @@
 #if NA_OS == NA_OS_WINDOWS
   #include "Windows.h"
   typedef TIME_ZONE_INFORMATION NATimeZone;
-#elif NA_OS == NA_OS_MAC_OS_X
+#elif NA_IS_POSIX
   typedef struct timezone NATimeZone;
 #endif
 
@@ -165,7 +165,7 @@ NA_API int16     naMakeShiftFromTimeZone(const NATimeZone* timeZone, NABool dayl
     const FILETIME* fileTime,
     const NATimeZone* timeZone,
     NABool daylightSaving);
-#elif NA_OS == NA_OS_MAC_OS_X
+#elif NA_IS_POSIX
   NA_API struct timespec naMakeTimeSpecFromDateTime(
     const NADateTime* dateTime,
     NABool daylightSaving);

--- a/code/NALib/src/NAUtility/NAFile.h
+++ b/code/NALib/src/NAUtility/NAFile.h
@@ -78,10 +78,12 @@ typedef struct NAFile NAFile;
   #define NA_FILE_OPEN_FLAGS_READ (O_RDONLY | O_BINARY)
   #define NA_FILE_OPEN_FLAGS_WRITE (O_WRONLY | O_CREAT | O_TRUNC | O_BINARY)
   #define NA_FILE_OPEN_FLAGS_APPEND (O_WRONLY | O_CREAT | O_APPEND | O_BINARY)
-#elif NA_OS == NA_OS_MAC_OS_X
+#elif NA_IS_POSIX
   #include <unistd.h>
   #include <dirent.h>
-  #include <copyfile.h>
+  #if NA_OS == NA_OS_MACOS
+    #include <copyfile.h>
+  #endif
   typedef off_t NAFileSize;     // Is signed (Important for negative offsets)
   #define NA_FILESIZE_BITS 64
   #define NA_FILESIZE_MAX NA_MAX_i64
@@ -91,6 +93,8 @@ typedef struct NAFile NAFile;
   #define NA_FILE_OPEN_FLAGS_READ (O_RDONLY) // There is no binary flag in Unix.
   #define NA_FILE_OPEN_FLAGS_WRITE (O_WRONLY | O_CREAT | O_TRUNC)
   #define NA_FILE_OPEN_FLAGS_APPEND (O_WRONLY | O_CREAT | O_APPEND)
+#else
+  #warning File IO not implemented for this system
 #endif
 
 


### PR DESCRIPTION
Most of this is just quick-and-dirty generalising the macOS parts to POSIX.

However, I am unsure about:

- the typedef in the datetime code for time_t
- can't run the example just yet because of CMake issues
- Not all of the POSIX assumptions might be entirely correct
- I am getting a warning:

```console
In file included from /usr/home/nico/src/NALib/code/NALib/src/NAVisual/Core/NAPNG.c:15:
In file included from /usr/home/nico/src/NALib/code/NALib/src/NAVisual/Core/../../NAMath/NAVectorAlgebra.h:1158:
In file included from /usr/home/nico/src/NALib/code/NALib/src/NAVisual/Core/../../NAMath/Core/NAVectorAlgebra/NAVectorAlgebraII.h:19:
In file included from /usr/home/nico/src/NALib/code/NALib/src/NAVisual/Core/../../NAMath/Core/NAVectorAlgebra/../../NARandom.h:54:
/usr/home/nico/src/NALib/code/NALib/src/NAVisual/Core/../../NAMath/Core/NARandomII.h:62:28: warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-const-int-float-conversion]
  return (float)naRand() * NA_INV_RAND_MAXf;
                           ^~~~~~~~~~~~~~~~
/usr/home/nico/src/NALib/code/NALib/src/NAVisual/Core/../../NAMath/Core/NARandomII.h:43:33: note: expanded from macro 'NA_INV_RAND_MAXf'
#define NA_INV_RAND_MAXf (1.f / RAND_MAX)
                              ~ ^~~~~~~~
/usr/include/stdlib.h:80:18: note: expanded from macro 'RAND_MAX'
#define RAND_MAX        0x7fffffff
                        ^~~~~~~~~~
3 warnings generated.
```
